### PR TITLE
Hide admin panel from visitors + UI polish (idle timer, primary button, admin banner)

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -228,6 +228,10 @@ class TimerEngine {
       kind = "work";
     }
 
+    // While idle (loaded but not started), keep the neutral accent so
+    // the timer doesn't read as "alarming red" before you press Start.
+    if (this.status === "idle") kind = "idle";
+
     this.onTick({
       status: this.status,
       displaySeconds,
@@ -836,6 +840,7 @@ async function boot() {
   state.isAdmin = params.has("admin");
   if (state.isAdmin) {
     $("#admin-area").hidden = false;
+    $("#admin-banner").hidden = false;
     $("#btn-admin-publish").addEventListener("click", adminPublish);
     $("#btn-admin-delete").addEventListener("click", adminDelete);
   }

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+  <div id="admin-banner" class="admin-banner" hidden>Admin Mode &middot; Publish enabled</div>
   <main id="app" class="app" data-kind="idle">
     <section class="timer-area" aria-live="polite">
       <div id="timer" class="timer" aria-label="Timer">20:00</div>
@@ -41,7 +42,7 @@
       <label for="paste-box" class="paste-label">Use your own workout (this device only)</label>
       <textarea id="paste-box" class="paste-box" rows="4" placeholder="Title on first line, then description..."></textarea>
       <div class="paste-actions">
-        <button id="btn-paste-save" class="btn" type="button">Use This Workout</button>
+        <button id="btn-paste-save" class="btn btn-primary" type="button">Use This Workout</button>
         <button id="btn-paste-copy" class="btn" type="button">Copy as JSON</button>
         <button id="btn-paste-clear" class="btn" type="button">Remove My Override</button>
       </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -228,6 +228,25 @@ body {
   align-items: center;
 }
 
+/* --- Admin mode banner (only visible with ?admin=1) --- */
+
+.admin-banner[hidden] { display: none; }
+
+.admin-banner {
+  /* Negative margin escapes the body's safe-area padding so the bar
+     spans the full viewport. Inner padding keeps the text inside the
+     5% TV-safe zone. */
+  margin: -5vh -5vw 1.5rem;
+  padding: 0.6rem 5vw;
+  background: var(--accent-work);
+  color: #fff;
+  text-align: center;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: clamp(0.8rem, 1.2vw, 1rem);
+}
+
 /* --- Admin area (only visible with ?admin=1) --- */
 
 /* [hidden] must win over display: grid below. */

--- a/public/styles.css
+++ b/public/styles.css
@@ -230,6 +230,9 @@ body {
 
 /* --- Admin area (only visible with ?admin=1) --- */
 
+/* [hidden] must win over display: grid below. */
+.admin-area[hidden] { display: none; }
+
 .admin-area {
   display: grid;
   gap: 0.5rem;


### PR DESCRIPTION
## Summary

Four small fixes:

1. **Hide the admin panel from non-admin visitors.** The `<section class="admin-area" hidden>` had `display: grid` in CSS which overrode the `hidden` attribute's default `display: none`. Anyone loading the page saw a "Publish for Everyone" textarea even though they couldn't actually publish. Fixed with `.admin-area[hidden] { display: none; }`.
2. **Timer stays neutral white while idle.** Previously, loading AMRAP / For Time / Stopwatch immediately set `kind="work"` so the big timer was red before the user pressed Start. Now `kind="idle"` while engine status is idle.
3. **Primary button on the visitor paste box.** `Use This Workout` now uses `btn-primary` styling so it stands out from `Copy as JSON` and `Remove My Override`.
4. **Admin-mode banner at the top.** `?admin=1` now reveals a red bar across the top reading "Admin Mode · Publish enabled" so it's obvious which tab/window has admin capability.

## Test plan

- [ ] Load `https://threetwone.com/` (no `?admin=1`) — admin section should NOT appear, no banner.
- [ ] Load `https://threetwone.com/?admin=1` — banner appears, dashed-red admin section appears.
- [ ] Timer shows white text on black with status "Ready" (not red AMRAP) on first load.
- [ ] After pressing Start: pre-countdown turns yellow, timer turns red on "go".
- [ ] `Use This Workout` button is visually distinct (white background) from the other two paste buttons.

https://claude.ai/code/session_019obdzE7EBxjACa6sb5cBAo

---
_Generated by [Claude Code](https://claude.ai/code/session_019obdzE7EBxjACa6sb5cBAo)_