### PR TITLE
Move admin UI to /admin path so Cloudflare Access can gate it

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,14 +160,17 @@ the page falls back to whatever the owner published (or the seed).
 **Copy as JSON** gives you a snippet you can paste into
 `workouts.json` if you want to persist it to git history.
 
-### Admin publish (`?admin=1`)
+### Admin publish (`/admin`)
 
-Visit `https://threetwone.com/?admin=1` to reveal a second
-textarea. Hitting **Publish** POSTs to `/api/admin/wod`, which is
-gated by Cloudflare Access. If you're already logged into the same
-Access identity as your other site, publishing is seamless — no
-password prompt, no token. **Unpublish** deletes the KV entry for
-the currently-browsed date.
+Visit `https://threetwone.com/admin`. Cloudflare Access intercepts
+the request and sends you through your identity provider. Once
+authenticated, the admin panel appears — a second textarea plus
+**Publish** / **Unpublish** buttons.
+
+**Publish** POSTs to `/api/admin/wod`, which is independently gated
+by the same Access policy. Double-gated: you need a valid Access
+session both to see the admin page and to write to the API.
+**Unpublish** deletes the KV entry for the currently-browsed date.
 
 Only the date being browsed gets published, so you can backfill
 yesterday or schedule tomorrow by navigating with ◀ / ▶ first.
@@ -194,7 +197,9 @@ npx wrangler kv namespace create WOD --preview
 ### Cloudflare Access (owner auth)
 
 1. **Zero Trust → Access → Applications → Add an application → Self-hosted.**
-2. Application domain: `threetwone.com` with path `/api/admin/*`.
+2. Application domains — add **both**:
+   - `threetwone.com` with path `/admin*` (gates the admin UI)
+   - `threetwone.com` with path `/api/admin/*` (gates the write API)
 3. Identity provider: whatever you already use on the other site.
 4. Policy: `Include → Emails → your@email.com` (or whatever rule
    you already have set up).

--- a/public/app.js
+++ b/public/app.js
@@ -833,11 +833,12 @@ async function boot() {
   $("#btn-mute").textContent = Audio.muted ? "Sound Off" : "Sound On";
   $("#btn-mute").setAttribute("aria-pressed", String(Audio.muted));
 
-  // Admin mode is a URL flag. Access still gates the actual API — the
-  // flag just reveals the UI. Non-admins who flip the flag see the form
-  // but any publish attempt gets 401 from the edge.
-  const params = new URLSearchParams(location.search);
-  state.isAdmin = params.has("admin");
+  // Admin mode is scoped to the /admin path, which is Access-gated at
+  // the edge. Unauthenticated visitors never reach this code — Access
+  // redirects them to login first. The Worker also re-verifies the
+  // JWT on every write, so even if the UI loaded somehow, publishing
+  // without a valid Access session still 401s.
+  state.isAdmin = location.pathname === "/admin" || location.pathname.startsWith("/admin/");
   if (state.isAdmin) {
     $("#admin-area").hidden = false;
     $("#admin-banner").hidden = false;

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#0a0a0a">
+  <!-- Anchors asset URLs to the site root so the app loads correctly
+       when served at /admin (Cloudflare Access-gated path) and not
+       just at /. Without this, /admin/styles.css etc. would 404. -->
+  <base href="/">
   <title>boxclock</title>
   <link rel="stylesheet" href="styles.css">
 </head>


### PR DESCRIPTION
## Summary

Moves admin-mode activation from `?admin=1` to the `/admin` path so Cloudflare Access can actually gate it. Fixes the "Network error: Failed to fetch" bug when clicking Publish without an Access session.

### Why

Current flow:
- Admin UI activates on `?admin=1` query string
- Query strings can't be matched by Access (Access matches paths only)
- `/api/admin/wod` IS Access-gated
- User clicks Publish → fetch to `/api/admin/wod` → Access redirects to login on `<team>.cloudflareaccess.com` → browser blocks cross-origin fetch redirect → "Failed to fetch"

The session cookie is never set because the user never visited a protected page first.

### Fix

- Admin UI now activates on `location.pathname === "/admin"`
- `<base href="/">` added to `index.html` so asset URLs still resolve correctly when loaded at `/admin`
- README updated with both Access destinations (`/admin*` and `/api/admin/*`)

After merge, visiting `/admin` triggers the full flow:
1. Access intercepts → login page → auth
2. Browser lands back at `/admin` with session cookie set
3. Admin UI loads
4. Publish button POSTs to `/api/admin/wod` → Access sees cookie → allows through → Worker verifies JWT → writes to KV

Double-gated: both the page and the API require a valid Access session.

## Prerequisites (already done on the user's side)

- [x] Cloudflare Access app updated to cover both `threetwone.com/admin*` and `threetwone.com/api/admin/*` with the same policy
- [x] Verified that unauthenticated visitors to `/admin` get prompted to log in

## Test plan

- [ ] Merge → deploy completes
- [ ] Visit `https://threetwone.com/admin` in a fresh browser → redirected to Access login
- [ ] After auth, admin UI appears with red banner
- [ ] Publish button works (no "Failed to fetch")
- [ ] Public site at `https://threetwone.com/` still works for non-admins
- [ ] Visitor paste box still functions normally

## Side effects

- `?admin=1` no longer activates admin mode (bookmarks will break — only affects the owner)
- Local `public/index.html` double-click no longer works because `<base href="/">` makes `/app.js` absolute. Use `npx wrangler dev` for local testing.

https://claude.ai/code/session_019obdzE7EBxjACa6sb5cBAo

---
_Generated by [Claude Code](https://claude.ai/code/session_019obdzE7EBxjACa6sb5cBAo)_