### PR TITLE
Move Access vars to Worker Secrets (fixes /admin Publish 401)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,10 +204,15 @@ npx wrangler kv namespace create WOD --preview
 4. Policy: `Include → Emails → your@email.com` (or whatever rule
    you already have set up).
 5. Session duration: `24 hours`.
-6. **After saving, copy the AUD tag** (Overview tab) into
-   `wrangler.jsonc → vars.ACCESS_AUD`.
-7. Copy your **Team subdomain** (the thing before
-   `.cloudflareaccess.com`) into `vars.ACCESS_TEAM_DOMAIN`.
+6. **Set ACCESS_AUD and ACCESS_TEAM_DOMAIN as Worker secrets**
+   (not committed to git):
+   - Cloudflare dashboard → **Workers & Pages → threetwoone →
+     Settings → Variables and Secrets → Add**
+   - Type: **Secret**, Name: `ACCESS_AUD`, Value: the AUD tag
+     from the Access app's Overview tab. Save.
+   - Repeat for `ACCESS_TEAM_DOMAIN`, value: just the subdomain
+     before `.cloudflareaccess.com`.
+   - Secrets persist across deploys; you only set them once.
 
 `/api/wod` (the public read) is **not** gated by Access — only
 `/api/admin/*` paths.

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -12,29 +12,24 @@
     "not_found_handling": "single-page-application"
   },
 
-  // ── Production bindings ─────────────────────────────────────────
-  //
+  // KV namespace binding for owner-published workouts.
   // `binding` must stay "WOD" — the Worker reads env.WOD directly.
-  // `id` is the production KV namespace (live site).
-  // `preview_id` is the separate namespace used by preview deploys
-  // and `wrangler dev`, so feature branches don't touch production.
-  //
-  // ACCESS_AUD is the Application Audience (AUD) tag from the
-  // Cloudflare Access app that gates /api/admin/*. Copy it from:
-  // Zero Trust → Access → Applications → your app → Overview.
-  //
-  // ACCESS_TEAM_DOMAIN is your team's subdomain (just the part
-  // before .cloudflareaccess.com). Find it at: Zero Trust →
-  // Settings → Custom Pages → Team domain.
+  // Preview id is used by wrangler dev and preview deploys so
+  // feature branches don't touch production data.
   "kv_namespaces": [
     {
       "binding": "WOD",
       "id": "fac81e3a4de146c6ba3657a43cd70435",
       "preview_id": "d8abe52875db4e06a7a82a87afab6225"
     }
-  ],
-  "vars": {
-    "ACCESS_AUD": "REPLACE_WITH_ACCESS_AUD_TAG",
-    "ACCESS_TEAM_DOMAIN": "REPLACE_WITH_TEAM_SUBDOMAIN"
-  }
+  ]
+
+  // ACCESS_AUD and ACCESS_TEAM_DOMAIN are NOT defined here — they
+  // live as Worker Secrets so the real values never land in git.
+  // Set them once via the Cloudflare dashboard:
+  //   Workers & Pages → threetwoone → Settings → Variables and
+  //   Secrets → "Add" → Type: Secret → name ACCESS_AUD / value
+  //   <your AUD>. Repeat for ACCESS_TEAM_DOMAIN.
+  // The Worker reads them from env just like vars; there's no code
+  // difference. Dashboard-set secrets persist across deploys.
 }


### PR DESCRIPTION
## Summary

Fixes the "Not authorized. Log in via Access first." error after a successful Access login. Root cause: `wrangler.jsonc` had `ACCESS_AUD` and `ACCESS_TEAM_DOMAIN` set to literal placeholder strings, so the Worker's JWT audience check rejected every authenticated request as fail-closed.

Removes both vars from `wrangler.jsonc` entirely. They move to Worker Secrets, set once via the Cloudflare dashboard. The Worker reads them from `env` exactly the same way — no code change needed.

This also satisfies the rule that no real Access values live in the repo.

## Required action before this works

After merging, in the Cloudflare dashboard:

**Workers & Pages → threetwoone → Settings → Variables and Secrets → Add**

Add two secrets:
1. Name: `ACCESS_AUD` · Type: **Secret** · Value: the AUD tag from the Access app's Overview tab
2. Name: `ACCESS_TEAM_DOMAIN` · Type: **Secret** · Value: just the team subdomain (the part before `.cloudflareaccess.com`)

Secrets persist across deploys; one-time setup.

## Test plan

- [ ] Merge → deploy completes
- [ ] Set both secrets in dashboard
- [ ] Visit `https://threetwone.com/admin` → Access login (if not authenticated)
- [ ] Paste a workout, click **Publish** → expect "Published for YYYY-MM-DD" success, no 401

https://claude.ai/code/session_019obdzE7EBxjACa6sb5cBAo

---
_Generated by [Claude Code](https://claude.ai/code/session_019obdzE7EBxjACa6sb5cBAo)_