### PR TITLE
Lengthen pre-start countdown from 3s to 10s for athlete setup

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -20,7 +20,10 @@
 // All pure state math — no DOM access in this section.
 
 const TICK_MS = 100;
-const PRE_START_SECS = 3; // "3, 2, 1, go"
+// 10-second pre-start gives athletes time to get into setup positions.
+// The first 7 seconds are silent (just the visual countdown); the last 3
+// fire the rising-pitch "3, 2, 1" beeps, then the long tone at "go".
+const PRE_START_SECS = 10;
 
 class TimerEngine {
   constructor() {
@@ -123,7 +126,8 @@ class TimerEngine {
       const prev = Math.ceil(this.preCountdown);
       this.preCountdown -= dt;
       const cur = Math.ceil(this.preCountdown);
-      if (cur < prev && cur >= 1) {
+      // Silent first 7s, audible 3-2-1 in the final stretch.
+      if (cur < prev && cur >= 1 && cur <= 3) {
         this.onEvent({ type: "preBeep", remaining: cur });
       }
       if (this.preCountdown <= 0) {


### PR DESCRIPTION
## Summary

Bumps the pre-start countdown to 10 seconds so athletes have time to step up to a barbell, chalk their hands, or get on the rower before the timer actually starts.

## Audio behavior

Unchanged in feel:
- **Seconds 10 → 4**: silent, just the visual countdown ticking down
- **Seconds 3 → 1**: the existing rising-pitch 3-2-1 beeps (660 → 770 → 880 Hz)
- **Second 0**: long "go" tone, then the workout timer starts

I considered beeping every second from 10 down but it dilutes the urgency of the final 3-2-1 and is noisy in a gym setting. Standard CrossFit-timer behavior is silent then 3-2-1.

## Test plan

- [ ] Load AMRAP / Intervals / EMOM / any preset
- [ ] Press Start
- [ ] Visual countdown shows 10, 9, 8, ... silently
- [ ] At 3, hear short beep; at 2, slightly higher beep; at 1, highest beep
- [ ] At 0, hear long tone; main timer begins counting

## Future option

If you want the pre-start length configurable per workout (e.g., 3 for solo training, 15 for a Hero WOD with complex setup), it's a small follow-up — `PRE_START_SECS` becomes a config value instead of a constant. Say the word.

https://claude.ai/code/session_019obdzE7EBxjACa6sb5cBAo

---
_Generated by [Claude Code](https://claude.ai/code/session_019obdzE7EBxjACa6sb5cBAo)_