### PR TITLE
For Time counts down from cap + 3-2-1 beeps before AMRAP/cap end

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ in `localStorage`.
 | Key | Preset     | Defaults                    |
 |-----|------------|-----------------------------|
 | 1   | AMRAP      | 20:00 countdown             |
-| 2   | For Time   | Count-up, optional cap      |
+| 2   | For Time   | Count-down from cap, or count-up if no cap |
 | 3   | EMOM       | 10 rounds × 60s             |
 | 4   | Intervals  | 8 × 20s/10s (Tabata button) |
 | 5   | Stopwatch  | Count-up, no cap            |

--- a/public/app.js
+++ b/public/app.js
@@ -156,7 +156,20 @@ class TimerEngine {
       return;
     }
 
-    if (this.flat.length === 0) return; // open-ended (stopwatch / For Time no cap)
+    if (this.flat.length === 0) {
+      // Non-segmented capped timers (AMRAP, For Time with cap):
+      // fire rising-pitch 3-2-1 beeps in the final 3 seconds before
+      // the cap triggers _finish. Without this they hit the cap in
+      // silence and the long tone arrives unannounced.
+      if (cfg.totalCap) {
+        const prev = Math.ceil(cfg.totalCap - (this.totalElapsed - dt));
+        const cur = Math.ceil(cfg.totalCap - this.totalElapsed);
+        if (cur < prev && cur <= 3 && cur >= 1) {
+          this.onEvent({ type: "segBeep", remaining: cur });
+        }
+      }
+      return; // open-ended path stops here (stopwatch, For Time no cap)
+    }
 
     const seg = this.flat[this.segIndex];
     const prevRemaining = Math.ceil(seg.seconds - this.segElapsed);
@@ -223,7 +236,9 @@ class TimerEngine {
       roundText = `Round ${seg.round}/${seg.totalRounds}`;
     } else if (cfg.direction === "down" && cfg.totalCap) {
       displaySeconds = Math.max(0, Math.ceil(cfg.totalCap - this.totalElapsed));
-      label = cfg.preset === "amrap" ? "AMRAP" : "Work";
+      label = cfg.preset === "amrap"   ? "AMRAP"
+            : cfg.preset === "forTime" ? "For Time"
+            :                            "Work";
       kind = "work";
     } else {
       // Stopwatch / For Time without cap
@@ -253,7 +268,10 @@ function buildConfig(preset, p = {}) {
     case "amrap":
       return { preset, direction: "down", totalCap: p.cap ?? 1200 };
     case "forTime":
-      return { preset, direction: "up", totalCap: p.cap || null };
+      // For Time WITH a cap counts down from the cap so athletes
+      // see time remaining, not elapsed (you're racing the clock).
+      // For Time WITHOUT a cap is open-ended count-up (stopwatch-like).
+      return { preset, direction: p.cap ? "down" : "up", totalCap: p.cap || null };
     case "emom": {
       const rounds = p.rounds ?? 10;
       const interval = p.interval ?? 60;


### PR DESCRIPTION
## Summary

Two changes to the timer audibles, both about closing gaps between expected and actual behavior on capped timers.

### 1. For Time counts DOWN when a cap is set

Previously For Time always counted up regardless of whether you set a cap. That's wrong for the use case — when you're racing against a 9-minute Fran cap, you want to see "8:34 left," not "0:26 elapsed."

After this change:
- **For Time + cap** → counts down from the cap (display shows time remaining)
- **For Time + no cap** → unchanged, open-ended count-up
- Display label is now "For Time" (was "Work" in the cap path)

### 2. 3-2-1 beeps fire before AMRAP / For Time cap

Previously AMRAP and capped For Time hit the cap in silence — the long tone fired the instant the cap was reached, with no warning. EMOM / Intervals / Circuit already had 3-2-1 in their final seconds because their countdown logic ran per-segment; AMRAP/For Time use a different code path (no segments) and that path didn't fire the cap-approach beeps.

Now the engine emits the same rising-pitch `segBeep` events in the final 3 seconds before the cap, matching the segment-end behavior. Same audio mapping (660 → 770 → 880 Hz), so it sounds identical.

### Unchanged

- 10-second pre-start lead (PR #7) still fires at the very beginning of every workout.
- Round transitions (EMOM 1→2, Intervals work→rest, Circuit station→station, etc.) unchanged.
- Stopwatch and uncapped For Time still fully silent (no cap to warn about).

## Test plan

- [ ] Load For Time with cap = 60s → start → see timer count 1:00 → 0:59 → ... → 0:04 silent → 0:03 / 0:02 / 0:01 rising beeps → long tone at 0:00 → "Done"
- [ ] Load For Time with no cap → start → counts up like a stopwatch with 10s pre-start
- [ ] Load AMRAP cap = 60s → same beep behavior as For Time cap
- [ ] EMOM, Intervals, Circuit unchanged (still beep on every segment end)

https://claude.ai/code/session_019obdzE7EBxjACa6sb5cBAo

---
_Generated by [Claude Code](https://claude.ai/code/session_019obdzE7EBxjACa6sb5cBAo)_