### PR TITLE
Cap inputs in decimal minutes (1.5 = 90s) instead of seconds

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -583,9 +583,14 @@ function toggleMute() {
 }
 
 // ── Config panel
+// CONFIG_FIELDS describes the controls each preset shows in the
+// config dialog. `unit: "min"` means the input is in decimal minutes
+// (e.g., 1.5 = 90s) but the value still stores in seconds for the
+// engine — conversion happens in the field render/save code below.
+// Defaults for "min" fields are written in minutes for readability.
 const CONFIG_FIELDS = {
-  amrap: [{ key: "cap", label: "Cap (seconds)", type: "number", default: 1200 }],
-  forTime: [{ key: "cap", label: "Cap (seconds, 0 = no cap)", type: "number", default: 0 }],
+  amrap: [{ key: "cap", label: "Cap (minutes)", type: "number", default: 20, unit: "min" }],
+  forTime: [{ key: "cap", label: "Cap (minutes, 0 = no cap)", type: "number", default: 0, unit: "min" }],
   emom: [
     { key: "rounds", label: "Rounds", type: "number", default: 10 },
     { key: "interval", label: "Every N seconds (60/120/180)", type: "number", default: 60 },
@@ -625,12 +630,22 @@ function renderConfigFields(preset) {
   const fields = CONFIG_FIELDS[preset] || [];
 
   for (const f of fields) {
-    const val = configDraft[f.key] ?? f.default;
+    // For min-unit fields the engine value is in seconds but the
+    // input is in minutes — convert in both directions at the boundary.
+    const isMin = f.unit === "min";
+    const storedSeconds = configDraft[f.key] ?? (isMin ? f.default * 60 : f.default);
+    const displayVal = isMin ? storedSeconds / 60 : storedSeconds;
+
     const lbl = document.createElement("label");
     const input = document.createElement("input");
     input.type = f.type;
-    input.value = val;
-    input.addEventListener("input", () => { configDraft[f.key] = Number(input.value); updateHints(); });
+    if (isMin) { input.step = "0.1"; input.min = "0"; }
+    input.value = displayVal;
+    input.addEventListener("input", () => {
+      const n = Number(input.value);
+      configDraft[f.key] = isMin ? Math.round(n * 60) : n;
+      updateHints();
+    });
     lbl.append(document.createTextNode(f.label + " "));
     lbl.append(input);
     const hint = document.createElement("span");


### PR DESCRIPTION
## Summary

The AMRAP cap and For Time cap inputs now take **minutes with decimals** instead of seconds. So:

| You type | Means |
|---|---|
| `20` | 20:00 |
| `1.5` | 01:30 |
| `12.5` | 12:30 |
| `0.5` | 00:30 |
| `0` (For Time only) | no cap |

The mm:ss helper text next to the input updates as you type, so it's always clear how the value parses.

### What didn't change

- Engine still uses **seconds** internally. No change to the timer logic.
- `workouts.json` entries that use `"cap": 900` keep working — the engine just receives seconds. The config UI shows `15` for that value now.
- Admin-published JSON in KV is unchanged (still seconds).
- EMOM interval, Intervals work/rest, Circuit station/rest stay in **seconds** — these are typically short sub-minute durations where decimal minutes would be awkward (would you really type `0.333` for a 20-second work interval?). Easy to flip them too if you want.

### Test plan

- [ ] Open Config → AMRAP → cap shows `20` (= 20 minutes)
- [ ] Type `1.5` → helper text shows `(01:30)`
- [ ] Save, start timer → counts down from 1:30
- [ ] Open Config → For Time → cap shows `0` initially → type `9` → helper shows `(09:00)` → start → counts down from 9:00
- [ ] Existing seeded `workouts.json` "Fran" entry (cap: 900) still loads as 15:00 cap

https://claude.ai/code/session_019obdzE7EBxjACa6sb5cBAo

---
_Generated by [Claude Code](https://claude.ai/code/session_019obdzE7EBxjACa6sb5cBAo)_