### PR TITLE
Surface specific 401 reason so we can debug Publish failures

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -832,7 +832,12 @@ async function adminPublish() {
         description: rest.join("\n").trim(),
       }),
     });
-    if (res.status === 401) { setAdminStatus("Not authorized. Log in via Access first.", "err"); return; }
+    if (res.status === 401) {
+      const body = await res.json().catch(() => ({}));
+      const r = body.reason || "unknown";
+      setAdminStatus(`Not authorized (${r}). See worker.js for what each reason means.`, "err");
+      return;
+    }
     if (!res.ok) { setAdminStatus(`Failed: ${res.status}`, "err"); return; }
     const { entry } = await res.json();
     state.serverWorkouts[date] = entry;
@@ -853,7 +858,11 @@ async function adminDelete() {
       method: "DELETE",
       credentials: "include",
     });
-    if (res.status === 401) { setAdminStatus("Not authorized.", "err"); return; }
+    if (res.status === 401) {
+      const body = await res.json().catch(() => ({}));
+      setAdminStatus(`Not authorized (${body.reason || "unknown"}).`, "err");
+      return;
+    }
     if (!res.ok) { setAdminStatus(`Failed: ${res.status}`, "err"); return; }
     delete state.serverWorkouts[date];
     renderWorkout();

--- a/src/worker.js
+++ b/src/worker.js
@@ -24,8 +24,10 @@ export default {
         return await handleGet(url, env);
       }
       if (pathname === "/api/admin/wod") {
-        const user = await verifyAccess(request, env);
-        if (!user) return json({ error: "unauthorized" }, 401);
+        const result = await verifyAccess(request, env);
+        if (!result.ok) {
+          return json({ error: "unauthorized", reason: result.reason }, 401);
+        }
         if (request.method === "POST")   return await handlePost(request, env);
         if (request.method === "DELETE") return await handleDelete(url, env);
         return json({ error: "method not allowed" }, 405);
@@ -73,41 +75,59 @@ async function handleDelete(url, env) {
 //
 // Cloudflare Access signs an RS256 JWT for every authenticated request
 // and puts it in `Cf-Access-Jwt-Assertion`. We verify:
-//   1. Signature against the team's public JWKS
-//   2. `aud` matches our Access application AUD tag (env.ACCESS_AUD)
-//   3. `exp` has not passed
-//   4. `iss` matches our team domain
-// Without all four, reject. This makes a broken/disabled Access policy
-// fail closed rather than fail open.
+//   1. Header is present (Access proxied this request)
+//   2. Both env secrets are configured
+//   3. Token is well-formed and uses RS256
+//   4. `aud` matches our Access application AUD tag (env.ACCESS_AUD)
+//   5. `iss` matches our team domain
+//   6. `exp` has not passed
+//   7. Signature validates against the team's public JWKS
+//
+// Returns { ok: true, user } on success, { ok: false, reason } otherwise.
+// The reason is surfaced in the 401 response body so the client can
+// distinguish "secrets unset" from "audience mismatch" from "expired
+// session" — turns six hours of debugging into one error message.
+
+const fail = reason => ({ ok: false, reason });
+const pass = user   => ({ ok: true, user });
 
 async function verifyAccess(request, env) {
   const jwt = request.headers.get("cf-access-jwt-assertion");
-  if (!jwt) return null;
-  if (!env.ACCESS_AUD || !env.ACCESS_TEAM_DOMAIN) return null;
+  if (!jwt) return fail("no_jwt_header");
+  if (!env.ACCESS_AUD)         return fail("env_aud_missing");
+  if (!env.ACCESS_TEAM_DOMAIN) return fail("env_team_domain_missing");
 
   const parts = jwt.split(".");
-  if (parts.length !== 3) return null;
+  if (parts.length !== 3) return fail("malformed_jwt");
   const [headerB64, payloadB64, sigB64] = parts;
 
   let header, payload;
   try {
     header = JSON.parse(b64urlToText(headerB64));
     payload = JSON.parse(b64urlToText(payloadB64));
-  } catch { return null; }
+  } catch { return fail("malformed_jwt"); }
 
-  if (header.alg !== "RS256" || !header.kid) return null;
+  if (header.alg !== "RS256") return fail("wrong_alg");
+  if (!header.kid)            return fail("missing_kid");
 
   const aud = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
-  if (!aud.includes(env.ACCESS_AUD)) return null;
-  if (typeof payload.exp !== "number" || payload.exp * 1000 < Date.now()) return null;
+  if (!aud.includes(env.ACCESS_AUD)) return fail("audience_mismatch");
+
   const expectedIss = `https://${env.ACCESS_TEAM_DOMAIN}.cloudflareaccess.com`;
-  if (payload.iss !== expectedIss) return null;
+  if (payload.iss !== expectedIss) return fail("issuer_mismatch");
+
+  if (typeof payload.exp !== "number" || payload.exp * 1000 < Date.now()) {
+    return fail("expired");
+  }
 
   // Fetch JWKS — edge-cached by Cloudflare, no in-process cache needed.
   const certsUrl = `${expectedIss}/cdn-cgi/access/certs`;
-  const certs = await fetch(certsUrl, { cf: { cacheTtl: 3600 } }).then(r => r.json());
+  let certs;
+  try {
+    certs = await fetch(certsUrl, { cf: { cacheTtl: 3600 } }).then(r => r.json());
+  } catch { return fail("jwks_fetch_failed"); }
   const jwk = certs.keys?.find(k => k.kid === header.kid);
-  if (!jwk) return null;
+  if (!jwk) return fail("kid_not_in_jwks");
 
   const key = await crypto.subtle.importKey(
     "jwk", jwk,
@@ -117,9 +137,9 @@ async function verifyAccess(request, env) {
   const data = new TextEncoder().encode(`${headerB64}.${payloadB64}`);
   const sig = b64urlToBytes(sigB64);
   const valid = await crypto.subtle.verify("RSASSA-PKCS1-v1_5", key, sig, data);
-  if (!valid) return null;
+  if (!valid) return fail("signature_invalid");
 
-  return { email: payload.email, sub: payload.sub };
+  return pass({ email: payload.email, sub: payload.sub });
 }
 
 function b64urlToText(s) {


### PR DESCRIPTION
## Summary

Right now the Worker collapses six different JWT verification failures into a single generic 401 with body `{"error": "unauthorized"}`. That's useless when debugging the "Publish gives 401 even after Access login" problem — could be unset secrets, wrong AUD, wrong team subdomain, expired session, etc., and we can't tell which.

After this change, the 401 body includes a `reason` field naming the exact check that failed. The admin UI displays it inline so the next time Publish errors, we'll know in one glance whether to:

- Add the secrets in the dashboard (`env_aud_missing`, `env_team_domain_missing`)
- Fix a typo (`audience_mismatch`, `issuer_mismatch`)
- Re-authenticate with Access (`expired`)
- Investigate something deeper (`signature_invalid`, `kid_not_in_jwks`)

## Reasons in the diagnostic

| Reason | What it means | How to fix |
|---|---|---|
| `no_jwt_header` | Access didn't proxy this request | Check Access app destinations include `threetwone.com/api/admin/*` |
| `env_aud_missing` | `ACCESS_AUD` secret not set | Dashboard → Worker → Variables → Add Secret |
| `env_team_domain_missing` | `ACCESS_TEAM_DOMAIN` secret not set | Same |
| `malformed_jwt` / `wrong_alg` / `missing_kid` | Cloudflare-internal — shouldn't happen | Capture and report |
| `audience_mismatch` | `ACCESS_AUD` secret doesn't match the Access app's AUD tag | Re-copy AUD from Zero Trust → app → Overview |
| `issuer_mismatch` | `ACCESS_TEAM_DOMAIN` is wrong | Should be just the subdomain, no `.cloudflareaccess.com` |
| `expired` | Session expired | Log into `/admin` again |
| `jwks_fetch_failed` / `kid_not_in_jwks` | JWKS fetch problem | Check team domain spelling, network |
| `signature_invalid` | Crypto verify failed | Check team domain — wrong team's JWKS |

## Test plan

- [ ] Merge → deploy
- [ ] Visit `/admin` (already authenticated), click Publish
- [ ] If still 401, error message will read e.g. `Not authorized (env_aud_missing)`
- [ ] Tell me the reason — that pins down the fix in one round-trip

https://claude.ai/code/session_019obdzE7EBxjACa6sb5cBAo

---
_Generated by [Claude Code](https://claude.ai/code/session_019obdzE7EBxjACa6sb5cBAo)_