### PR TITLE
UI polish: spacing, date picker chrome, sound icon, config modal

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -538,6 +538,10 @@ async function gotoDate(date) {
 $("#btn-prev").addEventListener("click", () => gotoDate(shiftDate(state.currentDate, -1)));
 $("#btn-next").addEventListener("click", () => gotoDate(shiftDate(state.currentDate, +1)));
 $("#btn-today").addEventListener("click", () => gotoDate(todayKey()));
+// The chevrons above the workout title duplicate prev/next for a more
+// picker-like feel right next to the date label itself.
+$("#btn-date-prev").addEventListener("click", () => gotoDate(shiftDate(state.currentDate, -1)));
+$("#btn-date-next").addEventListener("click", () => gotoDate(shiftDate(state.currentDate, +1)));
 
 // ── Paste box
 $("#btn-paste-save").addEventListener("click", () => {
@@ -578,7 +582,7 @@ $("#btn-paste-clear").addEventListener("click", () => {
 // ── Mute
 function toggleMute() {
   Audio.setMuted(!Audio.muted);
-  $("#btn-mute").textContent = Audio.muted ? "Sound Off" : "Sound On";
+  // The button is icon-only now — aria-pressed drives which SVG shows via CSS.
   $("#btn-mute").setAttribute("aria-pressed", String(Audio.muted));
 }
 
@@ -876,7 +880,6 @@ async function adminDelete() {
 async function boot() {
   Audio.init();
   loadPersisted();
-  $("#btn-mute").textContent = Audio.muted ? "Sound Off" : "Sound On";
   $("#btn-mute").setAttribute("aria-pressed", String(Audio.muted));
 
   // Admin mode is scoped to the /admin path, which is Access-gated at

--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,11 @@
     </section>
 
     <section class="workout-area">
-      <div class="workout-date" id="workout-date"></div>
+      <div class="date-row">
+        <button id="btn-date-prev" class="date-arrow" type="button" aria-label="Previous day">&lsaquo;</button>
+        <div class="workout-date" id="workout-date"></div>
+        <button id="btn-date-next" class="date-arrow" type="button" aria-label="Next day">&rsaquo;</button>
+      </div>
       <h1 id="workout-title" class="workout-title">No workout loaded</h1>
       <pre id="workout-body" class="workout-body"></pre>
     </section>
@@ -33,7 +37,18 @@
       <button id="btn-pause" class="btn" type="button" disabled>Pause</button>
       <button id="btn-reset" class="btn" type="button">Reset</button>
       <button id="btn-config" class="btn" type="button">Config</button>
-      <button id="btn-mute" class="btn" type="button" aria-pressed="false">Sound On</button>
+      <button id="btn-mute" class="btn btn-icon" type="button" aria-pressed="false" aria-label="Toggle sound">
+        <svg class="icon icon-sound-on" viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/>
+          <path d="M19.07 4.93a10 10 0 0 1 0 14.14"/>
+          <path d="M15.54 8.46a5 5 0 0 1 0 7.07"/>
+        </svg>
+        <svg class="icon icon-sound-off" viewBox="0 0 24 24" width="28" height="28" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/>
+          <line x1="23" y1="9" x2="17" y2="15"/>
+          <line x1="17" y1="9" x2="23" y2="15"/>
+        </svg>
+      </button>
     </nav>
 
     <nav class="day-nav" aria-label="Day navigation">

--- a/public/styles.css
+++ b/public/styles.css
@@ -36,7 +36,7 @@ body {
 .app {
   display: grid;
   grid-template-rows: auto auto auto auto auto;
-  gap: clamp(1rem, 2vh, 2rem);
+  gap: clamp(0.5rem, 1.2vh, 1.25rem);
   max-width: 1600px;
   margin: 0 auto;
   transition: --accent 400ms ease;
@@ -112,16 +112,46 @@ body {
   background: var(--panel);
   border: 1px solid var(--border);
   border-radius: 1rem;
-  padding: clamp(1rem, 3vw, 2rem);
+  padding: clamp(0.75rem, 2.5vw, 2rem);
   text-align: center;
 }
 
+/* Date row: ‹  TODAY — 2026-04-22  › */
+.date-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
 .workout-date {
-  font-size: clamp(0.9rem, 1.4vw, 1.25rem);
+  font-size: clamp(0.95rem, 1.5vw, 1.35rem);
   color: var(--muted);
   text-transform: uppercase;
   letter-spacing: 0.2em;
-  margin-bottom: 0.25rem;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.date-arrow {
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  font-size: clamp(1.5rem, 3vw, 2.25rem);
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.25rem 0.75rem;
+  border-radius: 0.5rem;
+  font-family: inherit;
+  transition: color 120ms ease, background 120ms ease;
+}
+.date-arrow:hover { color: var(--fg); background: rgba(255, 255, 255, 0.05); }
+.date-arrow:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
+  color: var(--fg);
 }
 
 .workout-title {
@@ -185,6 +215,22 @@ body {
   border-color: var(--fg);
 }
 .btn-primary:hover:not(:disabled) { border-color: var(--focus); }
+
+/* Icon-only button (speaker mute toggle).
+   Width is narrower than a label-text button and the two SVGs share
+   the same slot, with aria-pressed driving which one is visible. */
+.btn-icon {
+  min-width: 4rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.btn-icon .icon { display: block; }
+#btn-mute[aria-pressed="false"] .icon-sound-off { display: none; }
+#btn-mute[aria-pressed="true"]  .icon-sound-on  { display: none; }
+#btn-mute[aria-pressed="true"]  { color: var(--muted); }
 
 /* --- Paste box --- */
 
@@ -297,9 +343,11 @@ body {
 
 .preset-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 0.5rem;
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.25rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid var(--border);
 }
 
 .preset-btn {
@@ -308,12 +356,15 @@ body {
   color: var(--fg);
   border: 2px solid var(--border);
   border-radius: 0.5rem;
-  padding: 0.75rem;
-  font-size: clamp(0.9rem, 1.4vw, 1.1rem);
+  padding: 0.85rem 0.75rem;
+  font-size: clamp(0.95rem, 1.5vw, 1.1rem);
   font-weight: 600;
   cursor: pointer;
   font-family: inherit;
+  min-height: 3rem;
+  transition: border-color 120ms ease, background 120ms ease;
 }
+.preset-btn:hover:not([aria-selected="true"]) { border-color: var(--muted); }
 
 .preset-btn:focus-visible {
   outline: 3px solid var(--focus);
@@ -324,23 +375,28 @@ body {
   background: var(--fg);
   color: var(--bg);
   border-color: var(--fg);
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.08);
 }
 
 .config-fields {
   display: grid;
-  gap: 1rem;
-  margin-bottom: 1.5rem;
+  gap: 0.875rem;
+  margin-bottom: 1.25rem;
 }
+.config-fields:empty { margin-bottom: 0; }
 
 .config-fields label {
   display: grid;
-  gap: 0.25rem;
-  font-size: clamp(0.95rem, 1.4vw, 1.1rem);
+  gap: 0.35rem;
+  font-size: clamp(0.95rem, 1.4vw, 1.05rem);
+  font-weight: 500;
 }
 
 .config-fields .hint {
   color: var(--muted);
   font-size: 0.9em;
+  font-weight: 400;
+  font-variant-numeric: tabular-nums;
 }
 
 .config-fields input[type="number"],
@@ -396,10 +452,18 @@ body {
 /* --- Responsive --- */
 
 @media (max-width: 640px) {
-  :root { --safe: 2vh 3vw; }
+  /* No TV overscan on phones — reclaim the edge padding for content. */
+  :root { --safe: 1.25vh 3vw; }
   .timer { font-size: clamp(5rem, 28vw, 10rem); }
-  .btn { min-width: 5.5rem; }
+  .timer-area { padding: 0.5rem 0 0.75rem; }
+  .btn { min-width: 5.5rem; min-height: 3rem; padding: 0.6rem 1rem; }
   .station-row { grid-template-columns: 1fr 5rem auto; }
+  .app { gap: 0.6rem; }
+  .workout-area { padding: 0.75rem 1rem; }
+  .workout-title { font-size: clamp(1.5rem, 6vw, 2.5rem); }
+  .workout-body { font-size: clamp(1rem, 4.5vw, 1.5rem); }
+  .controls, .day-nav, .paste-actions { gap: 0.4rem; }
+  .paste-box { padding: 0.6rem; }
 }
 
 @media (min-width: 1200px) {


### PR DESCRIPTION
## Summary

Four UI polish changes bundled together. All visual, no behavior changes.

### 1. Tighter vertical spacing (mobile)

- `.app` grid gap halved
- `.workout-area` padding tightened on small screens
- Body safe-area padding shrunk on phones (no TV overscan to worry about)
- Workout title and body type scale shrunk on mobile so the controls don't get pushed below the fold

### 2. Date row reworked as a picker

```
 ‹  TODAY — 2026-04-22  ›
```

Chevron buttons (`‹` `›`) flank the date label. Both wired to the same `gotoDate(±1)` as the existing prev/next buttons below. The existing prev/today/next nav stays for tab order / TV remote.

### 3. Speaker icon on the mute button

Replaces "Sound On" / "Sound Off" text with two Feather-style inline SVGs sharing the same button slot. `aria-pressed` drives which icon shows via CSS — when muted the on-icon hides, the X-overlay icon appears, and the button color dims. No textContent juggling in JS anymore.

### 4. Config modal polish

- Preset grid: larger touch targets, hover state, divider below
- Selected preset has a subtle outer glow so it reads as active at a glance
- Form labels in config fields slightly tighter and a touch heavier
- Hint text uses tabular-nums so mm:ss helper values don't jitter

## Test plan

- [ ] Mobile: controls (Start / Pause / Reset / Config / Sound) all visible above the fold without scrolling
- [ ] Click ‹ next to the date → previous day loads (same as ◀ Prev button)
- [ ] Click ›  → next day
- [ ] Mute button shows a speaker icon, click → shows speaker-with-X
- [ ] Open Config: preset grid more spacious, selected preset has a glow
- [ ] Type `1.5` in AMRAP cap → hint shows `(01:30)` in tabular numerals

https://claude.ai/code/session_019obdzE7EBxjACa6sb5cBAo

---
_Generated by [Claude Code](https://claude.ai/code/session_019obdzE7EBxjACa6sb5cBAo)_