### PR TITLE
Add /wod workout library page + footer link from home

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -872,12 +872,91 @@ async function adminDelete() {
   }
 }
 
+// ── Library view (/wod) — browseable archive of published WODs
+//
+// Lives in this file rather than a separate page because the SPA
+// fallback at the Worker level serves index.html for /wod anyway, and
+// the cost of detecting the path here is one if-check.
+
+const LIBRARY_PATHS = new Set(["/wod", "/wod/"]);
+function isLibraryPath() { return LIBRARY_PATHS.has(location.pathname); }
+
+async function bootLibrary() {
+  // Hide the timer app entirely on /wod; show only the library section
+  // plus the footer link (kept for the "back to /" path).
+  document.querySelectorAll(
+    ".timer-area, .workout-area, .controls, .day-nav, .paste-area, .admin-area, .page-footer"
+  ).forEach(el => el.hidden = true);
+  $("#library-area").hidden = false;
+  document.title = "Workout Library — boxclock";
+
+  const list = $("#library-list");
+  const empty = $("#library-empty");
+  list.innerHTML = '<p class="library-empty">Loading…</p>';
+
+  try {
+    const res = await fetch("/api/wod/recent?days=30", { cache: "no-store" });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    list.innerHTML = "";
+    if (!data.entries?.length) { empty.hidden = false; return; }
+    for (const entry of data.entries) list.append(renderLibraryCard(entry));
+  } catch (err) {
+    list.innerHTML = "";
+    empty.textContent = `Couldn't load workouts (${err.message}). Try again.`;
+    empty.hidden = false;
+  }
+}
+
+function renderLibraryCard(entry) {
+  const card = document.createElement("article");
+  card.className = "library-card";
+
+  const date = document.createElement("div");
+  date.className = "library-date";
+  date.textContent = prettyLibraryDate(entry.date);
+
+  const title = document.createElement("h2");
+  title.className = "library-card-title";
+  title.textContent = entry.title || "Untitled";
+
+  const body = document.createElement("pre");
+  body.className = "library-card-body";
+  body.textContent = entry.description || "";
+
+  const open = document.createElement("a");
+  open.className = "library-open";
+  open.href = `/?date=${entry.date}`;
+  open.textContent = "Open in timer →";
+
+  card.append(date, title, body, open);
+  return card;
+}
+
+function prettyLibraryDate(iso) {
+  const [y, m, d] = iso.split("-").map(Number);
+  const dt = new Date(y, m - 1, d);
+  return dt.toLocaleDateString(undefined, {
+    weekday: "long", year: "numeric", month: "long", day: "numeric"
+  });
+}
+
 // ── Boot
 async function boot() {
+  if (isLibraryPath()) return bootLibrary();
+
   Audio.init();
   loadPersisted();
   $("#btn-mute").textContent = Audio.muted ? "Sound Off" : "Sound On";
   $("#btn-mute").setAttribute("aria-pressed", String(Audio.muted));
+
+  // Library cards link back to / with ?date=YYYY-MM-DD to open that
+  // day's WOD in the timer view directly.
+  const params = new URLSearchParams(location.search);
+  const dateParam = params.get("date");
+  if (dateParam && /^\d{4}-\d{2}-\d{2}$/.test(dateParam)) {
+    state.currentDate = dateParam;
+  }
 
   // Admin mode is scoped to the /admin path, which is Access-gated at
   // the edge. Unauthenticated visitors never reach this code — Access
@@ -905,13 +984,15 @@ async function boot() {
   // isn't blank while we hit KV.
   renderWorkout();
 
-  // Fetch today's server-published workout; swap it in if present.
-  await fetchServerWorkout(todayKey());
+  // Fetch the currently-viewed day's server-published workout; swap it
+  // in if present. (state.currentDate may be today or a ?date= override
+  // coming from a library link.)
+  await fetchServerWorkout(state.currentDate);
   renderWorkout();
 
-  // If today has no timer from the rendered entry, load the last-used preset.
-  const todayEntry = state.serverWorkouts[todayKey()] || state.workouts[todayKey()];
-  if (!todayEntry || !todayEntry.timer) {
+  // If the viewed day has no timer config, load the last-used preset.
+  const dayEntry = state.serverWorkouts[state.currentDate] || state.workouts[state.currentDate];
+  if (!dayEntry || !dayEntry.timer) {
     applyTimer({ preset: state.activePreset, ...(state.presetParams[state.activePreset] || {}) });
   }
 

--- a/public/index.html
+++ b/public/index.html
@@ -61,6 +61,18 @@
         <span id="admin-status" class="admin-status" aria-live="polite"></span>
       </div>
     </section>
+
+    <section class="library-area" id="library-area" hidden>
+      <a href="/" class="library-back">&larr; Back to timer</a>
+      <h1 class="library-title">Workout Library</h1>
+      <p class="library-sub" id="library-sub">Recent published workouts</p>
+      <div id="library-list" class="library-list" aria-live="polite"></div>
+      <p id="library-empty" class="library-empty" hidden>No published workouts yet.</p>
+    </section>
+
+    <footer class="page-footer">
+      <a href="/wod" class="footer-link">Browse workout library &rarr;</a>
+    </footer>
   </main>
 
   <dialog id="config-dialog" class="config-dialog" aria-labelledby="config-title">

--- a/public/styles.css
+++ b/public/styles.css
@@ -407,6 +407,132 @@ body {
   .controls, .day-nav { gap: 1.25rem; }
 }
 
+/* --- Page footer (link to /wod library, kept low-key on purpose) --- */
+
+.page-footer {
+  margin-top: 1rem;
+  padding: 0.75rem 0;
+  text-align: center;
+}
+
+.footer-link {
+  color: var(--muted);
+  text-decoration: none;
+  font-size: clamp(0.85rem, 1.2vw, 1rem);
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 1px;
+  transition: color 120ms ease, border-color 120ms ease;
+}
+.footer-link:hover { color: var(--fg); border-bottom-color: var(--muted); }
+.footer-link:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 4px;
+  color: var(--fg);
+}
+
+/* --- Workout library (/wod page) --- */
+
+.library-area[hidden] { display: none; }
+
+.library-area {
+  max-width: 900px;
+  margin: 0 auto;
+  width: 100%;
+  padding: 1rem 0;
+}
+
+.library-back {
+  display: inline-block;
+  color: var(--muted);
+  text-decoration: none;
+  font-size: clamp(0.9rem, 1.3vw, 1.05rem);
+  margin-bottom: 1rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  transition: color 120ms ease, background 120ms ease;
+}
+.library-back:hover { color: var(--fg); background: rgba(255, 255, 255, 0.05); }
+.library-back:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
+  color: var(--fg);
+}
+
+.library-title {
+  font-size: clamp(2rem, 4.5vw, 3.5rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+
+.library-sub {
+  color: var(--muted);
+  font-size: clamp(0.95rem, 1.4vw, 1.15rem);
+  margin: 0 0 1.5rem 0;
+}
+
+.library-list {
+  display: grid;
+  gap: clamp(0.75rem, 2vw, 1.25rem);
+}
+
+.library-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: clamp(1rem, 2.5vw, 1.75rem);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.library-date {
+  font-size: clamp(0.8rem, 1.2vw, 0.95rem);
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-variant-numeric: tabular-nums;
+}
+
+.library-card-title {
+  font-size: clamp(1.5rem, 3vw, 2.25rem);
+  font-weight: 800;
+  margin: 0;
+  letter-spacing: -0.02em;
+}
+
+.library-card-body {
+  font-size: clamp(1rem, 1.6vw, 1.25rem);
+  white-space: pre-wrap;
+  margin: 0.25rem 0 0.5rem 0;
+  font-family: inherit;
+  line-height: 1.4;
+}
+
+.library-open {
+  justify-self: start;
+  color: var(--muted);
+  text-decoration: none;
+  font-size: clamp(0.9rem, 1.3vw, 1.05rem);
+  padding: 0.4rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  transition: color 120ms ease, border-color 120ms ease;
+}
+.library-open:hover { color: var(--fg); border-color: var(--muted); }
+.library-open:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
+  color: var(--fg);
+}
+
+.library-empty {
+  color: var(--muted);
+  font-size: clamp(1rem, 1.5vw, 1.2rem);
+  text-align: center;
+  padding: 2rem 0;
+}
+
 /* Reduce motion */
 @media (prefers-reduced-motion: reduce) {
   .app[data-warn="true"] .timer { animation: none; }

--- a/src/worker.js
+++ b/src/worker.js
@@ -23,6 +23,9 @@ export default {
       if (pathname === "/api/wod" && request.method === "GET") {
         return await handleGet(url, env);
       }
+      if (pathname === "/api/wod/recent" && request.method === "GET") {
+        return await handleRecent(url, env);
+      }
       if (pathname === "/api/admin/wod") {
         const result = await verifyAccess(request, env);
         if (!result.ok) {
@@ -50,6 +53,37 @@ async function handleGet(url, env) {
   if (!raw) return json({ error: "not found" }, 404);
   // Stored as JSON already — just pass through.
   return new Response(raw, { headers: JSON_HEADERS });
+}
+
+// Returns owner-published WODs from KV for the last N days (max 90).
+// Used by the /wod library page to render a browseable archive.
+// Public read — same trust model as /api/wod.
+async function handleRecent(url, env) {
+  const daysParam = parseInt(url.searchParams.get("days") || "30", 10);
+  const days = Math.min(Math.max(daysParam || 30, 1), 90);
+
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - days);
+  const y = cutoff.getFullYear();
+  const m = String(cutoff.getMonth() + 1).padStart(2, "0");
+  const d = String(cutoff.getDate()).padStart(2, "0");
+  const cutoffKey = `wod:${y}-${m}-${d}`;
+
+  // KV list returns key names alphabetically. Since our keys are
+  // `wod:YYYY-MM-DD`, string-compare gives chronological order.
+  const list = await env.WOD.list({ prefix: "wod:" });
+  const recent = list.keys
+    .filter(k => k.name >= cutoffKey)
+    .sort((a, b) => b.name.localeCompare(a.name)); // most-recent first
+
+  const entries = (await Promise.all(recent.map(async k => {
+    const raw = await env.WOD.get(k.name);
+    if (!raw) return null;
+    try { return { date: k.name.slice(4), ...JSON.parse(raw) }; }
+    catch { return null; }
+  }))).filter(Boolean);
+
+  return json({ entries, days });
 }
 
 async function handlePost(request, env) {


### PR DESCRIPTION
## Summary

Adds a workout library page at `/wod` showing the last 30 days of owner-published WODs, plus a small link at the bottom of the home page to reach it.

### What it does

- **Home page** gets a quiet text link at the very bottom: "Browse workout library →". Styled muted, no button chrome — deliberately secondary so the timer UI stays primary.
- **`/wod` page** shows a list of dated cards. Each card has the date, title, full description, and an "Open in timer →" link that takes you back to `/` with `?date=YYYY-MM-DD` selected.
- **Back to timer** link at the top of `/wod` to return.

### How it works

- New Worker route `GET /api/wod/recent?days=30` (default 30, max 90) uses `env.WOD.list()` to enumerate KV keys, filters to the window, and returns entries sorted newest-first.
- SPA detects `/wod` in `boot()` and routes to `bootLibrary()` instead of the timer engine. Timer UI stays hidden on `/wod`.
- `/` now reads a `?date=YYYY-MM-DD` query param to pre-select that day, so library cards open directly into the right WOD.

### Trust model

`/api/wod/recent` is public, same as `/api/wod` — anyone can read what the owner published. Writes still go through Access-gated `/api/admin/wod` only.

### Cost

30 KV reads per library page load worst case. Free tier is 100k reads/day. Not a concern at any realistic traffic level.

### Test plan

- [ ] Publish 2–3 workouts on different dates via `/admin`
- [ ] Visit `/wod` → see them listed newest-first with friendly date headers
- [ ] Click "Open in timer →" on one → lands on `/` with that day's workout loaded
- [ ] On `/`, click "Browse workout library →" at the bottom → back to `/wod`
- [ ] `/wod` with no published WODs shows "No published workouts yet"
- [ ] `/wod` works on mobile (cards stack nicely, no horizontal scroll)

https://claude.ai/code/session_019obdzE7EBxjACa6sb5cBAo

---
_Generated by [Claude Code](https://claude.ai/code/session_019obdzE7EBxjACa6sb5cBAo)_